### PR TITLE
Add JIT to flash attention

### DIFF
--- a/flash_attention_jax/flash_attention.py
+++ b/flash_attention_jax/flash_attention.py
@@ -65,6 +65,7 @@ def _query_chunk_flash_attention(chunk_idx, q, k, v, key_mask):
     return out, row_sum, row_max
 
 @custom_vjp
+@jit
 def flash_attention(q, k, v, key_mask):
     q_len, dim, v_dim = *q.shape, v.shape[-1]
 


### PR DESCRIPTION
Thanks for implementing this! I implemented a quick benchmarking harness (at the end of this issue) and noted that the `flash_attention` implementation is much slower at low batch sizes without the proposed addition of `@jit`. For larger batches, it evens out, so maybe this isn't necessary. See benchmarking notes (of just the forward pass) below.

```
**Constants:**
SEQ_LEN: 16384
DIM: 512

**Without @jit:**
BATCH SIZE: 1
Standard attention: 0.005s
Rabe attention: 0.367s
Flash attention: 2.126s

BATCH SIZE: 4
Standard attention: 0.005s
Rabe attention: 0.464s
Flash attention: 2.394s

BATCH SIZE: 16
Standard attention: 0.005s
Rabe attention: 1.561s
Flash attention: 3.152s

BATCH SIZE: 64
Standard attention: OOM
Rabe attention: 6.066s
Flash attention: 6.991s


**With @jit:**
BATCH SIZE: 1
Standard attention: 0.005s
Rabe attention: 0.382s
Flash attention: 0.266s

BATCH SIZE: 4
Standard attention: 0.005s
Rabe attention: 0.464s
Flash attention: 0.533s

BATCH SIZE: 16
Standard attention: 0.005s
Rabe attention: 1.563s
Flash attention: 1.850s

BATCH SIZE: 64
Standard attention: OOM
Rabe attention: 6.059s
Flash attention: 6.980s
```

Benchmarking skeleton, for reference, run with the hyper-parameters mentioned above:
```python
import timeit

import jax
import jax.numpy as jnp

from flash_attention_jax.attention import attention
from flash_attention_jax.flash_attention import flash_attention, _query_chunk_flash_attention
from flash_attention_jax.rabe_attention import rabe_attention

REPEATS = 10
WARMUP = 3

def compute_attention(attention_func, q, k, v, key_mask):
    if attention_func == rabe_attention:
        return jax.vmap(attention_func)(q, k, v)
    else:
        return jax.vmap(attention_func)(q, k, v, key_mask)

def benchmark(attention_func):
    key = jax.random.PRNGKey(42)
    q = jax.random.normal(key, shape=(BATCH_SIZE, SEQ_LEN, DIM))
    k = jax.random.normal(key, shape=(BATCH_SIZE, SEQ_LEN, DIM))
    v = jax.random.normal(key, shape=(BATCH_SIZE, SEQ_LEN, DIM))
    key_mask = jnp.ones(shape=(BATCH_SIZE, SEQ_LEN))
    for _ in range(WARMUP):
            result = compute_attention(attention_func, q, k, v, key_mask)
    time = timeit.timeit(lambda: compute_attention(attention_func, q, k, v, key_mask), number=REPEATS)
    return time, result
```